### PR TITLE
Make $java_pkg and $enable_manager parameters overridable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class wowza (
   $wowzakey,
   $enable               = $wowza::params::enable,
   $java_heap_size       = $wowza::params::java_heap_size,
+  $java_pkg             = $wowza::params::java_pkg,
   $wowza_pkg            = $wowza::params::wowza_pkg,
   $wowza_pkg_version    = $wowza::params::wowza_pkg_version,
   $loadtest_ensure      = $wowza::params::loadtest_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@
 class wowza (
   $wowzakey,
   $enable               = $wowza::params::enable,
+  $enable_manager       = $wowza::params::enable_manager,
   $java_heap_size       = $wowza::params::java_heap_size,
   $java_pkg             = $wowza::params::java_pkg,
   $wowza_pkg            = $wowza::params::wowza_pkg,


### PR DESCRIPTION
On Debian 8 and later, the 'enable' operation isn't supported by systemd for SysV init scripts. Additionally, this PR makes the $java_pkg parameter overridable so another version of Java/OpenJDK can be installed. 