### PR TITLE
Manage admin.password file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@
 
 class wowza (
   $wowzakey,
+  $admin_password       = $wowza::params::admin_password,
+  $admin_user           = $wowza::params::admin_user,
   $enable               = $wowza::params::enable,
   $enable_manager       = $wowza::params::enable_manager,
   $java_heap_size       = $wowza::params::java_heap_size,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,14 @@
 #
 # === Parameters:
 #
+# [*admin_password*]
+#  Admin password used for the Web UI
+#  Defaults to 'admin'
+#
+# [*admin_user*]
+#  Admin user for the Web UI
+#  Defaults to 'admin'
+#
 # [*installdir*]
 #  Location to which the streaming engine is installed, the default here is what
 #  is used by the default wowza installer.
@@ -35,6 +43,8 @@
 #
 
 class wowza::params {
+  $admin_password       = 'admin'
+  $admin_user           = 'admin'
   $installdir           = '/usr/local/WowzaStreamingEngine'
   $java_heap_size       = '${com.wowza.wms.TuningHeapSizeProduction}'
   $wowza_pkg_version    = '4.0.0'

--- a/manifests/serverconfig.pp
+++ b/manifests/serverconfig.pp
@@ -2,7 +2,10 @@
 #  Class that does the default configuration for the wowzastreamingengine server.
 #
 
-class wowza::serverconfig {
+class wowza::serverconfig(
+  $admin_user     = $wowza::admin_user,
+  $admin_password = $wowza::admin_password,
+) {
 
   file { "${::wowza::installdir}/conf/Server.license":
     content => $::wowza::wowzakey,
@@ -49,6 +52,14 @@ class wowza::serverconfig {
     mode   => '0755',
     owner  => 'root',
     group  => 'root',
+  }
+
+  file { "${::wowza::installdir}/conf/admin.password":
+    ensure  => 'present',
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    content => template('wowza/admin.password.erb'),
   }
 
   #Change log configuration to log statistics in an awstats understandable format

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ class { 'wowza':
 }
 </code></pre>
 
+**NOTE**: The password for the Admin user defaults to 'admin'; it is strongly recommended to change this to a more secure one.
+
 ### Add Wowza application
 
 This adds a wowza application, defaults all work for a standard live streaming application. You can also use this to define a

--- a/templates/admin.password.erb
+++ b/templates/admin.password.erb
@@ -1,0 +1,6 @@
+#
+# admin.password - Admin password file for Wowza
+#
+# Managed by Puppet in the Wowza module
+#
+<%= @admin_user %> <%= @admin_password %> admin|advUser


### PR DESCRIPTION
This commit ensures that the admin password file is also managed by
Puppet. When there's no value specified, the user and password default
to 'admin'.